### PR TITLE
docs: add OctoAcme project management README in docs/

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,27 @@
+# OctoAcme Project Management — Overview
+
+This folder centralizes OctoAcme's project management processes, roles, templates, and checklists. Use this README to quickly understand our lifecycle, core workflows, where to find detailed guides, and how to contribute improvements.
+
+Summary
+OctoAcme runs projects through a repeatable lifecycle: Initiation (one‑pager, stakeholder alignment, go/no‑go), Planning (kickoff, prioritized backlog, estimates, Definition of Done), Execution & Tracking (sprints, project board, PR discipline, CI), Release & Deployment (pre‑release checks, staging smoke tests, rollback plans), and Close & Retrospective (capture learnings and action items). Core artifacts include the Project One‑pager, prioritized backlog, Risk Register, release notes, and retrospective action items. Templates and checklists are used at each stage to keep work visible and consistent.
+
+Key workflows and quality practices
+- Backlog-driven delivery with a project board (Backlog → Ready → In Progress → In Review → QA → Done).
+- Pull Request discipline: small changes, link to the issue and acceptance criteria, CI gating (tests, linting, security), and at least one approval before merge.
+- Testing: unit and integration tests, end‑to‑end smoke tests for critical flows, security scans in CI, and manual QA where needed.
+- Releases: documented pre‑release checks, staging verification, automated pipelines where possible, rollback/incident playbook, and post‑deploy verification.
+- Risk & communication: lightweight Risk Register updated regularly, weekly PM+PdM syncs, weekly status updates, and clear escalation paths.
+
+Roles and communication cadence
+- Personas: Product Managers (define outcomes & metrics), Project Managers (coordinate delivery, risks, and communications), Developers (implement & test), QA (validate acceptance), and Stakeholders (input & approvals).
+- Cadence: daily standups (team progress/blockers), weekly PM+PdM syncs, sprint demos/reviews, and monthly stakeholder updates. Use the issue and release templates and the provided communication templates for consistent updates.
+
+Docs index
+- docs/octoacme-project-management-overview.md
+- docs/octoacme-project-initiation.md
+- docs/octoacme-project-planning.md
+- docs/octoacme-execution-and-tracking.md
+- docs/octoacme-risks-and-communication.md
+- docs/octoacme-release-and-deployment.md
+- docs/octoacme-retrospective-and-continuous-improvement.md
+- docs/octo


### PR DESCRIPTION
Adds docs/README.md with a concise overview of OctoAcme’s project management processes (lifecycle, workflows, roles, communication cadence, quality practices) and links to the detailed docs in docs/.\n\nRefs #2